### PR TITLE
avoid loading auth0-lock server-side

### DIFF
--- a/pages/auth/sign-in.vue
+++ b/pages/auth/sign-in.vue
@@ -3,12 +3,11 @@
 </template>
 
 <script>
-import { show } from '~/utils/lock'
-
 export default {
   middleware: 'anonymous',
   mounted () {
-    show('auth0-lock')
+    const showLogin = require('~/utils/lock').showLogin
+    showLogin('auth0-lock')
   }
 }
 </script>

--- a/pages/auth/sign-off.vue
+++ b/pages/auth/sign-off.vue
@@ -3,11 +3,11 @@
 </template>
 
 <script>
-import { unsetToken } from '~/utils/auth'
-import { logout } from '~/utils/lock'
-
 export default {
   mounted () {
+    const unsetToken = require('~/utils/auth').unsetToken
+    const logout = require('~/utils/lock').logout
+
     unsetToken()
     logout()
   }

--- a/utils/lock.js
+++ b/utils/lock.js
@@ -27,5 +27,5 @@ const getOptions = (container) => {
   }
 }
 
-export const show = (container) => getLock(getOptions(container)).show()
+export const showLogin = (container) => getLock(getOptions(container)).show()
 export const logout = () => getLock().logout({ returnTo: getBaseUrl() })


### PR DESCRIPTION
auth0-lock only makes sense client-side, so use a webpack require
instead of a vue import so that it only loads client-side from within
the mount function.  This makes the nuxt code slightly more efficient

also, rename show to showLogin for clarity