### PR TITLE
Replace isServer(deprecated) in favor of process.server

### DIFF
--- a/middleware/check-auth.js
+++ b/middleware/check-auth.js
@@ -1,8 +1,8 @@
 import { getUserFromCookie, getUserFromLocalStorage } from '~/utils/auth'
 
-export default function ({ isServer, store, req }) {
-   // If nuxt generate, pass this middleware
-  if (isServer && !req) return
-  const loggedUser = isServer ? getUserFromCookie(req) : getUserFromLocalStorage()
+export default function ({ store, req }) {
+  // If nuxt generate, pass this middleware
+  if (process.server && !req) return
+  const loggedUser = process.server ? getUserFromCookie(req) : getUserFromLocalStorage()
   store.commit('SET_USER', loggedUser)
 }


### PR DESCRIPTION
https://nuxtjs.org/api/context/
I tried `process.SERVER_BUILD` because you are using it in _util/auth.js_ but it didn't work.
Had to use `process.server`