### PR TITLE
Fix auth0 clientId in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -40,7 +40,7 @@ export default {
       local: false,
       auth0: {
         domain: process.env.AUTH0_DOMAIN,
-        client_id: process.env.AUTH0_CLIENT_ID
+        clientId: process.env.AUTH0_CLIENT_ID
       }
     }
   },


### PR DESCRIPTION
The parameter name changed to clientId which was not reflected in this example. Parameter is correctly defined in https://auth.nuxtjs.org/providers/auth0/